### PR TITLE
Initial Shortcut API integration and CLI entry-point for initialize.py

### DIFF
--- a/pivotal-import/Pipfile
+++ b/pivotal-import/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 requests = "~=2.31.0"
 
 [dev-packages]
+black = "*"
 
 [requires]
 python_version = "3.10"

--- a/pivotal-import/Pipfile.lock
+++ b/pivotal-import/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6b7fa75d28bd7ac1eeb6c5c840519bdd3fc1e8ae450788a5b2e4fdde5aba35cf"
+            "sha256": "466ebdb8f9d95e7f5fd855c360b1c02c9aaffba388e920718d4e3937354c6d2e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -146,5 +146,91 @@
             "version": "==2.2.1"
         }
     },
-    "develop": {}
+    "develop": {
+        "black": {
+            "hashes": [
+                "sha256:2818cf72dfd5d289e48f37ccfa08b460bf469e67fb7c4abb07edc2e9f16fb63f",
+                "sha256:41622020d7120e01d377f74249e677039d20e6344ff5851de8a10f11f513bf93",
+                "sha256:4acf672def7eb1725f41f38bf6bf425c8237248bb0804faa3965c036f7672d11",
+                "sha256:4be5bb28e090456adfc1255e03967fb67ca846a03be7aadf6249096100ee32d0",
+                "sha256:4f1373a7808a8f135b774039f61d59e4be7eb56b2513d3d2f02a8b9365b8a8a9",
+                "sha256:56f52cfbd3dabe2798d76dbdd299faa046a901041faf2cf33288bc4e6dae57b5",
+                "sha256:65b76c275e4c1c5ce6e9870911384bff5ca31ab63d19c76811cb1fb162678213",
+                "sha256:65c02e4ea2ae09d16314d30912a58ada9a5c4fdfedf9512d23326128ac08ac3d",
+                "sha256:6905238a754ceb7788a73f02b45637d820b2f5478b20fec82ea865e4f5d4d9f7",
+                "sha256:79dcf34b33e38ed1b17434693763301d7ccbd1c5860674a8f871bd15139e7837",
+                "sha256:7bb041dca0d784697af4646d3b62ba4a6b028276ae878e53f6b4f74ddd6db99f",
+                "sha256:7d5e026f8da0322b5662fa7a8e752b3fa2dac1c1cbc213c3d7ff9bdd0ab12395",
+                "sha256:9f50ea1132e2189d8dff0115ab75b65590a3e97de1e143795adb4ce317934995",
+                "sha256:a0c9c4a0771afc6919578cec71ce82a3e31e054904e7197deacbc9382671c41f",
+                "sha256:aadf7a02d947936ee418777e0247ea114f78aff0d0959461057cae8a04f20597",
+                "sha256:b5991d523eee14756f3c8d5df5231550ae8993e2286b8014e2fdea7156ed0959",
+                "sha256:bf21b7b230718a5f08bd32d5e4f1db7fc8788345c8aea1d155fc17852b3410f5",
+                "sha256:c45f8dff244b3c431b36e3224b6be4a127c6aca780853574c00faf99258041eb",
+                "sha256:c7ed6668cbbfcd231fa0dc1b137d3e40c04c7f786e626b405c62bcd5db5857e4",
+                "sha256:d7de8d330763c66663661a1ffd432274a2f92f07feeddd89ffd085b5744f85e7",
+                "sha256:e19cb1c6365fd6dc38a6eae2dcb691d7d83935c10215aef8e6c38edee3f77abd",
+                "sha256:e2af80566f43c85f5797365077fb64a393861a3730bd110971ab7a0c94e873e7"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==24.3.0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.7"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
+                "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
+                "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==24.0"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08",
+                "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.12.1"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068",
+                "sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.2.0"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
+                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==4.10.0"
+        }
+    }
 }

--- a/pivotal-import/data/states.csv
+++ b/pivotal-import/data/states.csv
@@ -1,7 +1,0 @@
-Unscheduled,Unscheduled
-Unstarted,Unscheduled
-Planned,Ready for Development
-Started,In Development
-Finished,Ready for Review
-Rejected,Completed
-Accepted,Completed

--- a/pivotal-import/initialize.py
+++ b/pivotal-import/initialize.py
@@ -1,8 +1,8 @@
-# Reads a Pivotal export csv in order to prepare mapping CSVs 
+# Reads a Pivotal export csv in order to prepare mapping CSVs
 # for import into Shortcut.
 # See README.md for prerequisites, setup, and usage.
 
-""" 
+"""
 Given a Pivotal Tracker export file in csv format, writes states.csv and users.csv
 corresponding to the states and users found in the export file.
 
@@ -10,6 +10,88 @@ Pivotal export csv fields are explained here at the time of this writing:
 https://www.pivotaltracker.com/help/articles/csv_import_export
 
 Note: Pivotal Tracker does not support custom state types. There are only eight states,
-which are detailed here at the time of this writing: 
+which are detailed here at the time of this writing:
 https://www.pivotaltracker.com/help/articles/story_states/
 """
+
+import logging
+import os
+import sys
+
+import requests
+
+# Logging
+logger = logging.getLogger(__name__)
+# FIXME Make INFO default upon public release
+logging.basicConfig(level=logging.DEBUG)  # Change to INFO or DEBUG as needed
+
+# API Helpers
+sc_token = os.getenv("SHORTCUT_API_TOKEN")
+api_url_base = "https://api.app.shortcut.com/api/v3"
+headers = {
+    "Shortcut-Token": sc_token,
+    "Accept": "application/json; charset=utf-8",
+    "Content-Type": "application/json",
+}
+
+
+def sc_get(path, params={}):
+    url = api_url_base + path
+    logger.debug("GET url=%s params=%s headers=%s" % (url, params, headers))
+    resp = requests.get(url, headers=headers, params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def sc_post(path, data={}):
+    url = api_url_base + path
+    logger.debug("POST url=%s params=%s headers=%s" % (url, data, headers))
+    resp = requests.post(url, headers=headers, json=data)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def sc_put(path, data={}):
+    url = api_url_base + path
+    logger.debug("PUT url=%s params=%s headers=%s" % (url, data, headers))
+    resp = requests.put(url, headers=headers, json=data)
+    resp.raise_for_status()
+    return resp.json()
+
+
+# Mapping of Pivotal Tracker story states to Shortcut default Story Workflow State names
+pt_states = {
+    "Unscheduled": "Unscheduled",
+    "Unstarted": "Unscheduled",
+    "Planned": "Ready for Development",
+    "Started": "In Development",
+    "Finished": "Ready for Review",
+    "Rejected": "Completed",
+    "Accepted": "Completed",
+}
+
+
+def validate_config():
+    if sc_token is None:
+        logger.fatal(
+            "You must define a SHORTCUT_API_TOKEN environment variable with your Shortcut API token."
+        )
+        sys.exit(1)
+
+
+def main():
+    validate_config()
+    workflows = sc_get("/workflows")
+    print("Your Shortcut workspace's Story Worklows:")
+    for workflow in workflows:
+        if workflow["name"] == "Engineering":
+            print('  {id} : "{name}" [default]'.format_map(workflow))
+        else:
+            print('  {id} : "{name}"'.format_map(workflow))
+        for workflow_state in workflow["states"]:
+            print('    {id} : [{type}] "{name}"'.format_map(workflow_state))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR doesn't complete the requirements for this story, but I wanted to get these changes in to allow others to leverage them as we work:

* Adds the [Black](https://black.readthedocs.io/en/stable/) Python formatter as a dev dependency
* Sets up initial `if __name__ == "__main__":` entry point for `initialize.py` with basic validation and example of calling Shortcut API for the workspace's Story Workflows