### PR TITLE
[pivotal] Import Pivotal reviewers as Shortcut Story followers

### DIFF
--- a/pivotal-import/pivotal_import.py
+++ b/pivotal-import/pivotal_import.py
@@ -109,12 +109,13 @@ col_map = {
 }
 
 nested_col_map = {
-    "blocker": "blocker",
     "blocker status": "blocker_state",
-    "task": "task_titles",
-    "task status": "task_states",
+    "blocker": "blocker",
     "comment": ("comments", parse_comment),
     "owned by": "owners",
+    "reviewer": "reviewers",
+    "task status": "task_states",
+    "task": "task_titles",
 }
 
 # These are the keys that are currently correctly populated in the
@@ -129,6 +130,7 @@ select_keys = {
         "estimate",
         "external_id",
         "external_links",
+        "follower_ids",
         "labels",
         "name",
         "owner_ids",
@@ -241,10 +243,18 @@ def build_entity(ctx, d):
         owners = d.get("owners")
         if owners:
             d["owner_ids"] = [
-                # filter out woners that aren't found
+                # filter out owners that aren't found
                 user_to_sc_id[owner]
                 for owner in owners
                 if owner in user_to_sc_id
+            ]
+
+        reviewers = d.get("reviewers")
+        if reviewers:
+            d["follower_ids"] = [
+                user_to_sc_id[reviewer]
+                for reviewer in reviewers
+                if reviewer in user_to_sc_id
             ]
 
         # Custom Fields

--- a/pivotal-import/pivotal_import_test.py
+++ b/pivotal-import/pivotal_import_test.py
@@ -6,8 +6,10 @@ def create_test_ctx():
         "priority_config": {"p2 - medium": "priority_medium_123"},
         "priority_custom_field_id": "priority_123",
         "user_config": {
-            "Daniel McFadden": "daniel_member_id",
             "Amy Williams": "amy_member_id",
+            "Daniel McFadden": "daniel_member_id",
+            "Emmanuelle Charpentier": "emmanuelle_member_id",
+            "Giorgio Parisi": "giorgio_member_id",
         },
         "workflow_config": {"unstarted": 400001, "started": 400002, "done": 400003},
     }
@@ -55,10 +57,25 @@ def test_parse_owners():
             "Daniel McFadden",
         ]
     } == parse_row(
-        # purposefully using different variations of comma separated
-        # labels
         ["Amy Williams", "Daniel McFadden"],
         ["owned by", "owned by"],
+    )
+
+
+def test_parse_reviewers():
+    assert {
+        "reviewers": [
+            "Amy Williams",
+            "Giorgio Parisi",
+            "Emmanuelle Charpentier",
+        ]
+    } == parse_row(
+        [
+            "Amy Williams",
+            "Giorgio Parisi",
+            "Emmanuelle Charpentier",
+        ],
+        ["reviewer", "reviewer", "reviewer"],
     )
 
 
@@ -193,6 +210,10 @@ def test_build_story_user_mapping():
             "story_type": "bug",
             "owners": ["Amy Williams", "Daniel McFadden"],
         },
+        {
+            "story_type": "chore",
+            "reviewers": ["Giorgio Parisi", "Emmanuelle Charpentier"],
+        },
     ]
 
     assert [
@@ -222,6 +243,21 @@ def test_build_story_user_mapping():
                 ],
             },
             "parsed_row": rows[1],
+        },
+        {
+            "type": "story",
+            "entity": {
+                "story_type": "chore",
+                "follower_ids": [
+                    ctx["user_config"]["Giorgio Parisi"],
+                    ctx["user_config"]["Emmanuelle Charpentier"],
+                ],
+                "labels": [
+                    {"name": PIVOTAL_TO_SHORTCUT_LABEL},
+                    {"name": PIVOTAL_TO_SHORTCUT_RUN_LABEL},
+                ],
+            },
+            "parsed_row": rows[2],
         },
     ] == [build_entity(ctx, d) for d in rows]
 


### PR DESCRIPTION
Given Shortcut does not have a formal "reviewer" role on its Stories, adding Pivotal reviewers as Shortcut Story followers will ensure they see all activity related to those stories in their Shortcut Activity Feed. They can also search for all of their followed stories using the Stories Page filters.

In subsequent commits we intend to import more of the review-specific information about a story as a comment on the story.