### PR TITLE
Limit Shortcut API requests to respect rate limits

### DIFF
--- a/pivotal-import/Pipfile
+++ b/pivotal-import/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 requests = "~=2.31.0"
+pyrate-limiter = "~=3.6.0"
 
 [dev-packages]
 black = "*"

--- a/pivotal-import/Pipfile.lock
+++ b/pivotal-import/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8793a8cf03a2d5f187f3514aaa885cc228abe6e9308ab6010e8fcacf475f28a3"
+            "sha256": "1188fa67d6c5a816c82f2110a42ee8d36c2ca8ce92acd3209f19ea66ff446085"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -127,6 +127,15 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==3.6"
+        },
+        "pyrate-limiter": {
+            "hashes": [
+                "sha256:390f97066b322732e498c9e921fbdfd31d9ec0070a14e06da9af0efc62e091e4",
+                "sha256:715e9f08c6fe2a00d0cae5b1a6647d68ffeb2a54dc0cc2cff4e046b067ce6da4"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8' and python_version < '4.0'",
+            "version": "==3.6.0"
         },
         "requests": {
             "hashes": [
@@ -329,11 +338,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
-                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+                "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0",
+                "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==4.10.0"
+            "version": "==4.11.0"
         }
     }
 }

--- a/pivotal-import/README.md
+++ b/pivotal-import/README.md
@@ -8,7 +8,7 @@ In order to run this, you will require a Pivotal account and the ability to sign
 
 1. Sign up for a Shortcut account at [https://www.shortcut.com/signup](https://www.shortcut.com/signup).
    - **NOTE:** Do not run this importer against an existing Shortcut workspace that already has data you wish to keep.
-1. [Create an API token](https://app.shortcut.com/settings/account/api-tokens) and [export it into your environment](../Authentication.md).
+1. [Create a new API token](https://app.shortcut.com/settings/account/api-tokens) and [export it into your environment](../Authentication.md). Ensure you use this token only for this importer, so that you aren't rate limited unexpectedly by the Shortcut API.
 1. Export your Pivotal project to CSV and save the file to `data/pivotal_export.csv`.
 1. Create/Invite all users you want to reference into your Shortcut workspace.
    - **NOTE:** If you're not on a Shortcut trial, please [reach out to our support team](https://help.shortcut.com/hc/en-us/requests/new) before running this import to make sure you're not billed for users that you want to be disabled after import.

--- a/pivotal-import/delete_imported_entities.py
+++ b/pivotal-import/delete_imported_entities.py
@@ -27,8 +27,9 @@ def delete_entity(entity_type, entity_id):
     if prefix:
         try:
             sc_delete(f"{prefix}{entity_id}")
-        except requests.HTTPError:
+        except requests.HTTPError as err:
             printerr(f"Unable to delete {entity_type} {entity_id}")
+            printerr(f"Error: {err}")
             return None
 
     return True
@@ -38,6 +39,8 @@ def main(argv):
     args = parser.parse_args(argv[1:])
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
+
+    print_rate_limiting_explanation()
 
     counter = Counter()
     with open(shortcut_imported_entities_csv) as csvfile:
@@ -49,6 +52,11 @@ def main(argv):
             if args.apply:
                 if delete_entity(entity_type, entity_id):
                     counter[entity_type] += 1
+                    # Enhancement: This can be replaced with a link to a relevant label,
+                    # which is done during import because there is a trivially simple
+                    # place in the import code flow to print the Shortcut-provided
+                    # app_url for the import-specific label.
+                    print("Deleted {} {}".format(entity_type, entity_id))
             else:
                 counter[entity_type] += 1
 

--- a/pivotal-import/pivotal_import.py
+++ b/pivotal-import/pivotal_import.py
@@ -509,6 +509,7 @@ def main(argv):
 
     cfg = load_config()
     ctx = build_ctx(cfg)
+    print_rate_limiting_explanation()
     process_pt_csv_export(ctx, cfg["pt_csv_file"], entity_collector)
 
     created_entities = entity_collector.commit()


### PR DESCRIPTION
From the primary commit message:

Shortcut's REST API has an advertised rate limit of 200 requests per
minute. If 200 or more requests are made within one minute, API
clients should expect to receive responses with HTTP status code 429
until enough time has past for the total number of requests made by
their API token over the course of the last minute to have dropped
below 200.

This commit introduces rate limiting on the client (this importer)
side, such that users of this pivotal-import tool should never be
throttled by Shortcut's API.

Since the importer is single-threaded and the rate limiting is handled
by an algorithm operating entirely within the Python process' memory,
the script should never pause for more than the max_delay set and
should never throw an exception related to the rate limit delay being
exceeded. It has been configured to throw an exception in case these
assumptions do not hold, so that errors are not passed by silently.

The rate has been set to 195 requests per minute to keep us
comfortably below the rate limit threshold (which is 199 inclusive)
without wasting too much possible capacity.

The max_delay has been set to 70 seconds to ensure (1) in a case where
the max number of requests are made within 1 second, we have a full
minute to regain capacity on the Shortcut API side without being
throttled by the 200 reqs per minute limit, while also (2) adding a
buffer of 10 seconds (1 min == 60 seconds, 60 + 10 == 70 seconds) to
account for possible mismatched clock times between the client running
this script and the Shortcut API server accepting requests.