### PR TITLE
[pivotal] Initialize Team/Group

### DIFF
--- a/pivotal-import/.gitignore
+++ b/pivotal-import/.gitignore
@@ -2,6 +2,7 @@ data/emails_to_invite.csv
 data/pivotal_export.csv
 data/priorities.csv
 data/shortcut_custom_fields.csv
+data/shortcut_groups.csv
 data/shortcut_imported_entities.csv
 data/shortcut_workflows.csv
 data/shortcut_users.csv

--- a/pivotal-import/lib.py
+++ b/pivotal-import/lib.py
@@ -171,6 +171,8 @@ def print_custom_fields_tree(custom_fields):
                             custom_field_value
                         )
                     )
+    printerr("Shortcut Custom Fields")
+    printerr("======================")
     printerr("\n".join(output_lines))
 
 
@@ -192,6 +194,8 @@ def print_groups_tree(groups):
         for group in groups:
             writer.writerow({"group_name": group["name"], "group_id": group["id"]})
             output_lines.append('Group/Team {id} : "{name}"'.format_map(group))
+    printerr("Shortcut Teams/Groups")
+    printerr("=====================")
     printerr("\n".join(output_lines))
 
 
@@ -228,6 +232,8 @@ def print_workflows_tree(workflows):
                         workflow_state
                     )
                 )
+    printerr("Shortcut Workflows")
+    printerr("==================")
     printerr("\n".join(output_lines))
 
 
@@ -245,15 +251,17 @@ def default_group_id():
 
     if group_id is None:
         printerr(
-            f"""[Warning] Failed to find a Team (called "Group" in the Shortcut API) to automatically assign imported stories and epics to.
+            f"""
+[Warning] Failed to find a Team (called "Group" in the Shortcut API) to automatically assign imported stories and epics to.
           If you would like to assign a Team/Group for the stories and epics you import, please:
-  1. Review the Shortcut Teams/Groups printed below (also written to {shortcut_workflows_csv} for reference).
+  1. Review the Shortcut Teams/Groups printed below (also written to {shortcut_groups_csv} for reference).
   2. Copy the numeric ID of your desired Team/Group (group_id column in the CSV).
   3. Paste it as the "group_id" value in your config.json file.
   4. Rerun initialize.py.
 """
         )
         print_groups_tree(groups)
+        printerr("\n")
         return None
     else:
         return group_id
@@ -275,13 +283,15 @@ def default_priority_custom_field_id():
 
     if priority_custom_field_id is None:
         printerr(
-            f"""[Problem] The Priority custom field is disabled or not found in your Shortcut workspace. Please:
+            f"""
+[Problem] The Priority custom field is disabled or not found in your Shortcut workspace. Please:
  1. Review the Shortcut Custom Fields printed below (also written to {shortcut_custom_fields_csv} for reference).
  2. Copy the UUID of your desired Custom Field (custom_field_id column in the CSV).
  3. Paste it as the "priority_custom_field_id" value in your config.json file.
  4. Rerun initialize.py."""
         )
         print_custom_fields_tree(custom_fields)
+        printerr("\n")
         return None
     else:
         return priority_custom_field_id
@@ -301,7 +311,8 @@ def default_workflow_id():
 
     if workflow_id is None:
         printerr(
-            f"""[Problem] Failed to find the default Story Workflow in your Shortcut workspace, please:
+            f"""
+[Problem] Failed to find the default Story Workflow in your Shortcut workspace, please:
   1. Review the Shortcut Workflows printed below (also written to {shortcut_workflows_csv} for reference).
   2. Copy the numeric ID of your desired Workflow (workflow_id column in the CSV).
   3. Paste it as the "workflow_id" value in your config.json file.
@@ -309,6 +320,7 @@ def default_workflow_id():
 """
         )
         print_workflows_tree(workflows)
+        printerr("\n")
         return None
     else:
         return workflow_id


### PR DESCRIPTION
From primary commit message:

NOTE: These changes affect _only_ the initialization part of the
importer. Future commits will need to leverage the initialized data to
set a team/group for imported Shortcut entities.

Teams are a central part of the Shortcut model, but users may or may
not have set up multiple teams when trying out this importer.

During initialization of the importer, these changes will search in
the user's Shortcut workspace for the default team named "Team 1". If
that team is found, it will be automatically set as the target team
during the import, meaning that all epics and stories imported will
have that Team assigned to them.

If the default team is not found, rather than printing out
"[Problem]", the script will print out "[Warning]" so that, if the
user desires, they can look at the teams/groups printed to the console
or consult the data/groups.csv file to pick a Team to use for the
import. If no team/group is configured in the `config.json` file, the
intention is that the importer will simply omit assigning a team to
imported epics and stories.