### PR TITLE
[pivotal] Import deadline for Pivotal releases

### DIFF
--- a/pivotal-import/pivotal_import.py
+++ b/pivotal-import/pivotal_import.py
@@ -130,6 +130,7 @@ select_keys = {
         "comments",
         "created_at",
         "custom_fields",
+        "deadline",
         "description",
         "estimate",
         "external_id",

--- a/pivotal-import/pivotal_import.py
+++ b/pivotal-import/pivotal_import.py
@@ -95,19 +95,19 @@ def parse_priority(priority):
 
 
 col_map = {
-    "id": "external_id",
-    "title": "name",
-    "description": "description",
-    "type": "story_type",
-    "estimate": ("estimate", int),
-    "priority": ("priority", parse_priority),
-    "current state": "pt_state",
-    "labels": ("labels", parse_labels),
-    "url": ("external_links", url_to_external_links),
-    "created at": ("created_at", parse_date),
     "accepted at": ("accepted_at", parse_date),
+    "created at": ("created_at", parse_date),
+    "current state": "pt_state",
     "deadline": ("deadline", parse_date),
+    "description": "description",
+    "estimate": ("estimate", int),
+    "id": "external_id",
+    "labels": ("labels", parse_labels),
+    "priority": ("priority", parse_priority),
     "requested by": "requester",
+    "title": "name",
+    "type": "story_type",
+    "url": ("external_links", url_to_external_links),
 }
 
 nested_col_map = {

--- a/pivotal-import/pivotal_import_test.py
+++ b/pivotal-import/pivotal_import_test.py
@@ -392,6 +392,7 @@ def test_build_release():
     d = {
         "story_type": "release",
         "name": "A Release",
+        "deadline": "2014-10-15T00:00:00",
     }
 
     assert {
@@ -405,6 +406,7 @@ def test_build_release():
                 {"name": PIVOTAL_TO_SHORTCUT_RUN_LABEL},
                 {"name": PIVOTAL_RELEASE_TYPE_LABEL},
             ],
+            "deadline": "2014-10-15T00:00:00",
         },
         "parsed_row": d,
     } == build_entity(ctx, d)


### PR DESCRIPTION
_(This PR is based on the feature branch for https://github.com/useshortcut/api-cookbook/pull/59 with the expectation that that will be merged first and this PR will then target `main`)._

From the primary commit message:

Pivotal's export includes a Deadline entry for Pivotal Releases. This
importer was already importing releases as Shortcut stories, setting
their Shortcut story type to "chore", and labelling them as a
release. This commit ensures the deadline field is also imported and
set as the Shortcut Story's deadline.

Note that Shortcut stories of any type can have a deadline set, not
just releases, but Pivotal supports deadlines only on releases.