### PR TITLE
[pivotal] Import Iterations

### DIFF
--- a/pivotal-import/README.md
+++ b/pivotal-import/README.md
@@ -38,7 +38,6 @@ The following are known limitations:
   - Imported stories that had Pivotal reviews have an additional comment with a table that lists all of the story reviews from Pivotal (reviewer, review type, and review status).
   - Imported stories that had Pivotal reviews have a label in Shortcut of `pivotal-had-review`.
 - **No story blockers:** Pivotal story blockers (the relationships between stories) are not imported.
-- **No iterations:** Pivotal iterations are not imported.
 - **Epics are imported as unstarted:** Imported epics are set to an unstarted "Todo" state.
 - **No redirects:** The URLs in the descriptions and comments of your Pivotal stories/epics are not rewritten to point to imported Shortcut stories/epics; they remain unchanged.
 - **No attachments:** The attachments (including Google Drive attachments) are not imported into Shortcut.

--- a/pivotal-import/delete_imported_entities.py
+++ b/pivotal-import/delete_imported_entities.py
@@ -23,6 +23,8 @@ def delete_entity(entity_type, entity_id):
         prefix = "/stories/"
     elif entity_type == "epic":
         prefix = "/epics/"
+    elif entity_type == "iteration":
+        prefix = "/iterations/"
 
     if prefix:
         try:

--- a/pivotal-import/lib.py
+++ b/pivotal-import/lib.py
@@ -198,7 +198,7 @@ def print_groups_tree(groups):
         writer.writeheader()
         for group in groups:
             writer.writerow({"group_name": group["name"], "group_id": group["id"]})
-            output_lines.append('Group/Team {id} : "{name}"'.format_map(group))
+            output_lines.append('Team/Group {id} : "{name}"'.format_map(group))
     printerr("Shortcut Teams/Groups")
     printerr("=====================")
     printerr("\n".join(output_lines))

--- a/pivotal-import/lib.py
+++ b/pivotal-import/lib.py
@@ -485,13 +485,19 @@ def parse_comment(s):
             author = author.strip()
         created_at = match.group(3)
         if created_at is not None:
-            created_at = parse_date(created_at.strip())
+            created_at = parse_date_time(created_at.strip())
         return {"text": txt, "author": author, "created_at": created_at}
     else:
         return {"text": s}
 
 
 def parse_date(d: str):
+    """Parse the string as a date, then return as a string in ISO 8601 format."""
+    dt = datetime.strptime(d, "%b %d, %Y").date()
+    return dt.strftime("%Y-%m-%d")
+
+
+def parse_date_time(d: str):
     """Parse the string as a datetime, then return as a string in ISO 8601 format."""
     return datetime.strptime(d, "%b %d, %Y").isoformat()
 
@@ -502,7 +508,7 @@ def identity(x):
 
 
 def print_stats(stats):
-    plurals = {"story": "stories", "epic": "epics"}
+    plurals = {"story": "stories", "epic": "epics", "iteration": "iterations"}
     for k, v in stats.items():
         plural = plurals.get(k, k + "s")
         print(f"  - {plural.capitalize()} : {v}")

--- a/pivotal-import/lib.py
+++ b/pivotal-import/lib.py
@@ -89,6 +89,7 @@ def sc_post(path, data={}):
     url = api_url_base + path
     logger.debug("POST url=%s params=%s headers=%s" % (url, data, headers))
     resp = requests.post(url, headers=headers, json=data)
+    logger.debug(f"POST response: {resp.status_code} {resp.text}")
     resp.raise_for_status()
     return resp.json()
 

--- a/pivotal-import/lib_test.py
+++ b/pivotal-import/lib_test.py
@@ -108,4 +108,8 @@ def test_parse_comment_without_suffix():
 
 
 def test_parse_date():
-    assert parse_date("Oct 15, 2014") == "2014-10-15T00:00:00"
+    assert parse_date("Oct 15, 2024") == "2024-10-15"
+
+
+def test_parse_date_time():
+    assert parse_date_time("Oct 15, 2014") == "2014-10-15T00:00:00"

--- a/pivotal-import/pivotal_import_test.py
+++ b/pivotal-import/pivotal_import_test.py
@@ -114,6 +114,8 @@ def test_build_story_with_comments():
                 {"name": PIVOTAL_TO_SHORTCUT_RUN_LABEL},
             ],
         },
+        "iteration": None,
+        "pt_iteration_id": None,
         "parsed_row": d,
     } == build_entity(ctx, d)
 
@@ -169,6 +171,8 @@ def test_build_story_with_reviews():
                         {"name": PIVOTAL_HAD_REVIEW_LABEL},
                     ],
                 },
+                "iteration": None,
+                "pt_iteration_id": None,
                 "parsed_row": rows[0],
             },
             {
@@ -201,6 +205,8 @@ def test_build_story_with_reviews():
                         {"name": PIVOTAL_HAD_REVIEW_LABEL},
                     ],
                 },
+                "iteration": None,
+                "pt_iteration_id": None,
                 "parsed_row": rows[1],
             },
         ]
@@ -238,6 +244,8 @@ def test_build_story_priority_mapping():
                     {"name": PIVOTAL_TO_SHORTCUT_RUN_LABEL},
                 ],
             },
+            "iteration": None,
+            "pt_iteration_id": None,
             "parsed_row": rows[0],
         },
         {
@@ -250,6 +258,8 @@ def test_build_story_priority_mapping():
                     {"name": PIVOTAL_TO_SHORTCUT_RUN_LABEL},
                 ],
             },
+            "iteration": None,
+            "pt_iteration_id": None,
             "parsed_row": rows[1],
         },
     ] == [build_entity(ctx, d) for d in rows]
@@ -280,6 +290,8 @@ def test_build_story_workflow_mapping():
                     {"name": PIVOTAL_TO_SHORTCUT_RUN_LABEL},
                 ],
             },
+            "iteration": None,
+            "pt_iteration_id": None,
             "parsed_row": rows[0],
         },
         {
@@ -293,6 +305,8 @@ def test_build_story_workflow_mapping():
                     {"name": PIVOTAL_TO_SHORTCUT_RUN_LABEL},
                 ],
             },
+            "iteration": None,
+            "pt_iteration_id": None,
             "parsed_row": rows[1],
         },
     ] == [build_entity(ctx, d) for d in rows]
@@ -323,6 +337,8 @@ def test_build_story_user_mapping():
                     {"name": PIVOTAL_TO_SHORTCUT_RUN_LABEL},
                 ],
             },
+            "iteration": None,
+            "pt_iteration_id": None,
             "parsed_row": rows[0],
         },
         {
@@ -339,6 +355,8 @@ def test_build_story_user_mapping():
                     {"name": PIVOTAL_TO_SHORTCUT_RUN_LABEL},
                 ],
             },
+            "iteration": None,
+            "pt_iteration_id": None,
             "parsed_row": rows[1],
         },
     ] == [build_entity(ctx, d) for d in rows]
@@ -370,6 +388,8 @@ def test_build_no_group():
                     {"name": PIVOTAL_TO_SHORTCUT_RUN_LABEL},
                 ],
             },
+            "iteration": None,
+            "pt_iteration_id": None,
             "parsed_row": rows[0],
         },
         {
@@ -382,6 +402,8 @@ def test_build_no_group():
                     {"name": PIVOTAL_TO_SHORTCUT_RUN_LABEL},
                 ],
             },
+            "iteration": None,
+            "pt_iteration_id": None,
             "parsed_row": rows[1],
         },
     ] == [build_entity(ctx, d) for d in rows]
@@ -408,6 +430,8 @@ def test_build_release():
             ],
             "deadline": "2014-10-15T00:00:00",
         },
+        "iteration": None,
+        "pt_iteration_id": None,
         "parsed_row": d,
     } == build_entity(ctx, d)
 
@@ -434,6 +458,8 @@ def test_build_epic():
                 {"name": PIVOTAL_TO_SHORTCUT_RUN_LABEL},
             ],
         },
+        "iteration": None,
+        "pt_iteration_id": None,
         "parsed_row": d,
     } == build_entity(ctx, d)
 
@@ -449,7 +475,7 @@ def test_assign_stories_to_epics():
                     "labels": [{"name": "an epic name"}],
                 },
             },
-            # This story is not assigned to an epic, and so should not have an epic_id.
+            # This story is not assigned to an epic, and so should not have an epic_id
             {"type": "story", "entity": {"name": "A Story 2"}},
         ],
         [
@@ -476,12 +502,83 @@ def test_assign_stories_to_epics():
     ]
 
 
+def test_assign_stories_to_iterations():
+    assert assign_stories_to_iterations(
+        [
+            {
+                "type": "story",
+                "entity": {
+                    "name": "A Story 1",
+                },
+                "iteration": "123|2024-01-01|2025-01-01",
+                "pt_iteration_id": "123",
+            },
+            # This story is not assigned to an iteration, and so should not have an iteration_id
+            {
+                "type": "story",
+                "entity": {"name": "A Story 2"},
+                "iteration": None,
+                "pt_iteration_id": None,
+            },
+        ],
+        [
+            {
+                "type": "iteration",
+                "pt_iteration_id": "123",
+                "entity": {
+                    "name": "PT 123",
+                    "start_date": "2024-01-01",
+                    "end_date": "2025-01-01",
+                },
+                "imported_entity": {"id": 1234},
+            }
+        ],
+    ) == [
+        {
+            "type": "story",
+            "entity": {
+                "name": "A Story 1",
+                "iteration_id": 1234,
+            },
+            "iteration": "123|2024-01-01|2025-01-01",
+            "pt_iteration_id": "123",
+        },
+        {
+            "type": "story",
+            "entity": {"name": "A Story 2"},
+            "iteration": None,
+            "pt_iteration_id": None,
+        },
+    ]
+
+
 def test_entity_collector():
     entity_collector = EntityCollector()
 
-    entity_collector.collect({"type": "story", "entity": {"name": "A Story 1"}})
-    entity_collector.collect({"type": "story", "entity": {"name": "A Story 2"}})
-    entity_collector.collect({"type": "story", "entity": {"name": "A Story 3"}})
+    entity_collector.collect(
+        {
+            "type": "story",
+            "entity": {"name": "A Story 1"},
+            "iteration": None,
+            "pt_iteration_id": None,
+        }
+    )
+    entity_collector.collect(
+        {
+            "type": "story",
+            "entity": {"name": "A Story 2"},
+            "iteration": None,
+            "pt_iteration_id": None,
+        }
+    )
+    entity_collector.collect(
+        {
+            "type": "story",
+            "entity": {"name": "A Story 3"},
+            "iteration": None,
+            "pt_iteration_id": None,
+        }
+    )
 
     created = entity_collector.commit()
 
@@ -511,26 +608,46 @@ def test_entity_collector_with_epics():
     entity_collector = EntityCollector()
 
     # Given: a sequence of stories and epics
-    entity_collector.collect({"type": "story", "entity": {"name": "A Story 1"}})
+    entity_collector.collect(
+        {
+            "type": "story",
+            "entity": {"name": "A Story 1"},
+            "iteration": None,
+            "pt_iteration_id": None,
+        }
+    )
     entity_collector.collect(
         {
             "type": "story",
             "entity": {"name": "A Story 2", "labels": [{"name": "my-epic-label-2"}]},
+            "iteration": None,
+            "pt_iteration_id": None,
         }
     )
     entity_collector.collect(
         {
             "type": "epic",
             "entity": {"name": "An Epic", "labels": [{"name": "my-epic-label"}]},
+            "iteration": None,
+            "pt_iteration_id": None,
         }
     )
     entity_collector.collect(
         {
             "type": "epic",
             "entity": {"name": "Another Epic", "labels": [{"name": "my-epic-label-2"}]},
+            "iteration": None,
+            "pt_iteration_id": None,
         }
     )
-    entity_collector.collect({"type": "story", "entity": {"name": "A Story 3"}})
+    entity_collector.collect(
+        {
+            "type": "story",
+            "entity": {"name": "A Story 3"},
+            "iteration": None,
+            "pt_iteration_id": None,
+        }
+    )
 
     # When: the entities are commited/crread
     created = entity_collector.commit()


### PR DESCRIPTION
From primary commit message:

The rows of the Pivotal export CSV each represent either a story or an
epic. The Pivotal iteration to which a story might belong is found in
an Iteration column, and when that is defined there are also populated
Iteration Start and Iteration End columns.

This commit extends the build_entity function to return an iteration
and pt_iteration_id entry for every row. The iteration entry is a
string containing the id, start, and end dates. A string was chosen
instead of a dict or other data structure, because those are not
hashable and thus not includable in a Python set, whereas a string
is. At commit() time, the unique set of these iteration strings is
used to create Shortcut Iterations.

The title of imported Iterations is "PT {id}" where id is the Pivotal
iteration ID. The start and end dates are also imported. At this time,
no Team/Group association is made for imported Iterations.

At commit() time this code also ensures each story is associated with
the correct imported Iteration.