### PR TITLE
[pivotal] Add more detailed user-facing documentation

### DIFF
--- a/pivotal-import/README.md
+++ b/pivotal-import/README.md
@@ -2,30 +2,41 @@ This script imports a Pivotal Tracker CSV export file into a Shortcut workspace.
 
 [Walk-through Video](https://vimeo.com/931197039?share=copy) _(recorded 2024-04-05 using api-cookbook commit [1c12c1cc03](https://github.com/useshortcut/api-cookbook/tree/1c12c1cc035f4321f6b09a0e264eec740ddf2e88))_
 
+This README contains detailed usage instructions, but if you just want to jump in, clone this repository and at its root run:
+
+```
+make import
+```
+
+Follow the instructions printed to the console to configure and complete your import.
+
 # Prerequisites and Setup
 
 In order to run this, you will require a Pivotal account and the ability to sign up for a Shortcut account, as well as a working internet connection.
 
 1. Sign up for a Shortcut account at [https://www.shortcut.com/signup](https://www.shortcut.com/signup).
    - **NOTE:** Do not run this importer against an existing Shortcut workspace that already has data you wish to keep.
-1. [Create a new API token](https://app.shortcut.com/settings/account/api-tokens) and [export it into your environment](../Authentication.md). Ensure you use this token only for this importer, so that you aren't rate limited unexpectedly by the Shortcut API.
+1. [Create a new Shortcut API token](https://app.shortcut.com/settings/account/api-tokens) and [export it into your environment](../Authentication.md).
 1. Export your Pivotal project to CSV and save the file to `data/pivotal_export.csv`.
 1. Create/Invite all users you want to reference into your Shortcut workspace.
    - **NOTE:** If you're not on a Shortcut trial, please [reach out to our support team](https://help.shortcut.com/hc/en-us/requests/new) before running this import to make sure you're not billed for users that you want to be disabled after import.
 1. Run `make import` to perform a dry-run of the import.
    - Follow instructions printed to the console to ensure the mapping of Pivotal and Shortcut data is complete and correct.
-   - Refer to `data/priorities.csv`, `data/states.csv`, and `data/users.csv` to review these mappings.
+   - You may edit the following files generated during initialization, to change how story priorities, story workflow states, and users are mapped between your Pivotal export and Shortcut workspace:
+     - `data/priorities.csv`
+     - `data/states.csv`
+     - `data/users.csv`
+   - This script will also write the following files during initialization to help you fill out the mapping files above:
+     - `data/shortcut_groups.csv` is a listing of all your Shortcut Teams/Groups
+     - `data/shortcut_users.csv` is a listing of all users in your Shortcut workspace
+     - `data/shortcut_imported_entities.csv` contains a listing of all entities created during import
    - Ensure a `group_id` is set in your `config.json` file if you want to assign the epics and stories you import to a Shortcut Team/Group.
 1. If the dry-run output looks correct, you can apply the import to your Shortcut workspace by running `make import-apply`
    - The console should print a link to an import-specific Shortcut label page that you can review to find all imported Stories and Epics.
    - If you run the importer multiple times, you can review all imported Stories and Epics by visiting Settings > Labels and then searching for the `pivotal->shortcut` label and clicking on it.
 1. If you find that you need to adjust your configuration or your Pivotal data and try again, you can run `make delete` to review a dry-run and `make delete-apply` to actually delete the imported Shortcut epics and stories listed in `data/shortcut_imported_entities.csv`. You can also archive or delete content in the Shortcut application if needed.
 
-# Operation
-
-Before you run the import, you should go through the steps in **Prerequisites and Setup**. You can check that the prerequisites are superficially met by running [`pivotal_import.py`](pivotal_import.py) which by default will not write any changes to your Shortcut workspace. You can use this mode to validate that you've configured the import correctly.
-
-If `pivotal_import.py` completes without errors, you can run the script with the `--apply` flag, which will enable writing to the Shortcut API.
+You can run `make clean` if you want to start over, but be aware this will delete all but your `data/pivotal_export.csv` file.
 
 # Known Limitations
 
@@ -50,6 +61,135 @@ Please check [currently open issues](https://github.com/useshortcut/api-cookbook
 # Customization
 
 It's possible that this tool does not do exactly what you'd like it to - if that's the case, we have tried to make it straightforward to modify. Make reference to the [Shortcut API](https://developer.shortcut.com/api/rest/v3) and the other examples in this cookbook, and please let us know in [our Discord](https://discord.gg/shortcut-community-887801174496006216) what you're doing with it!
+
+# Implementation
+
+This project is written in Python (3.10) using `pipenv` for version and dependency management and `make` as the intended CLI for normal operation.
+
+This project is not structured as a Python module, but instead as independent Python scripts.
+
+First we'll cover the `make` targets, and then provide a deeper look at the Python scripts.
+
+## make targets
+
+The following `make` targets are supported (alphabetic order):
+
+- `clean`
+  - Deletes `config.json` and all files in the `data/` folder, except the user's Pivotal export at `data/pivotal_export.csv`
+- `delete`
+  - This is a dry-run version of the `delete-apply` target.
+  - This target runs `pipenv run python delete_imported_entities.py`
+- `delete-apply`
+  - This target runs `pipenv run python delete_imported_entities.py --apply`
+  - After an import completes, a `data/shortcut_imported_entities.csv` file is written.
+  - This target uses that CSV to make `DELETE` calls to the Shortcut API, deleting all entities imported during that last run.
+  - If you've done multiple imports and need to delete all entities, visit the Settings > Labels > `pivotal->shortcut` label page to see all epics and stories imported by this tool.
+- `import`
+  - This is a dry-run version of the `import-apply` target.
+- `import-apply`
+  - This target depends on the `initialize` target.
+  - This target runs `pipenv run python pivotal_import.py --apply` to execute an import of the stories, epics, and iterations found in the user's Pivotal export `data/pivotal_export.csv` into the Shortcut workspace associated with the user's `SHORTCUT_API_TOKEN` environment variable.
+  - See the section below on `pivotal_import.py` for more details.
+- `initialize`
+  - This target depends on the `setup` target.
+  - This target runs `pipenv run python initialize.py` to initialize the user's import.
+  - Initialization includes populating and verifying the `config.json` file for single config values, as well as the `data/priorities`, `data/states.csv`, and `data/users.csv` files that represent mappings from Pivotal to Shortcut.
+  - See the section below on `initialize.py` for more details.
+- `lint` (development)
+  - This target runs linting/formatting using the Black formatter.
+- `setup`
+  - This target checks for the presence of the `pipenv` command on the user's `PATH`, and having found it runs `pipenv install` to download all primary Python dependencies.
+- `setup-dev`
+  - This target does what `setup` does, but also installs development-only Python dependencies.
+- `test`
+  - This target runs this project's Python tests using `pytest`
+
+The `clean`, `lint`, `setup`, and `test` scripts are the backing for the `make` targets of the same name.
+
+## Python: `initialize.py`
+
+For `initialize.py` to complete successfully, the following must be true:
+
+- A `config.json` file at the root of this repo—populated by `initialize.py` if not present—must encode a single JSON object with the following fields (note that in practice, users will only need to edit `workflow_id` and/or `priority_custom_field_id`):
+  - `group_id` is a Shortcut ID representing the Team/Group the user wants all epics and stories to be assigned to during import.
+    - Value may be `null`, but the field itself is required.
+    - See `data/groups.csv` (populated by `initialize.py`) for Teams/Groups in your Shortcut workspace.
+  - `priorities_csv_file` is the location of a file containing all the Priority custom field values from your Shortcut workspace.
+    - Warning: Don't change this configuration value unless you're hacking on the project.
+  - `priority_custom_field_id` is the Shortcut ID of the built-in Custom Field titled "Priority" in your Shortcut workspace.
+    - To customize this value,
+  - `priorities_csv_file` is the location of a file containing the user's desired mapping between PT priorities and Shortcut Priority custom field values. See `data/shortcut_custom_fields.csv` (populated by `initialize.py`) for a full listing of custom fields in the Shortcut workspace.
+  - `pt_csv_file` is the location of your Pivotal CSV export.
+    - By default, this value is `data/pivotal_export.csv`.
+    - Warning: Don't change this configuration value unless you're hacking on the project.
+  - `states_csv_file` is the location of a file containing the user's desired mapping between PT story state and Shortcut story workflow state. See `data/shortcut_workflows.csv` for a complete listing of all workflows and their constituent workflow states found in the Shortcut workspace.
+    - Warning: Don't change this configuration value unless you're hacking on the project.
+  - `users_csv_file` is the location of a file containing the user's desired mapping between PT users and Shortcut users. This is populated from the users found in the PT export. The user needs to invite missing users to Shortcut (or use a blanket user if they don't care about preserving that information) and fill in all blank email fields in this CSV for the importer to run successfully.
+    - If the user fills out the `users_csv_file` before inviting people to their Shortcut workspace, the importer will print a listing of all emails found in that CSV file but not in the Shortcut workspace, at which point it is trivial to copy and paste that list of emails into Shortcut's UI for inviting users in bulk.
+    - Warning: Don't change this configuration value unless you're hacking on the project.
+  - `workflow_id` is the Shortcut ID of the story workflow that should be used to configure mappings between PT story states and Shortcut workflow states. The Shortcut _workflow_ contains many _workflow states_. The `states_csv_file` is that mapping between the actual states; this `workflow_id` is used to fetch candidate workflow states and automatically map workflow states where possible.
+
+NOTE: In practice, you will only need to edit the `config.json` file if you need to edit the `workflow_id` or `priority_custom_field_id`.
+
+The `config.json` file is loaded into memory when the `pivotal_import.py` is run, to ascertain the values and file locations specified above. If the `config.json` file is not valid, the `initialize.py` script will print the reasons why and provide instructions for correcting what is wrong.
+
+With a valid `config.json` file, the importer will attempt to populate the `data/priorities.csv`, `data/states.csv`, and `data/users.csv` files automatically, printing to the console any issues it has with automatically identifying these mappings.
+
+### Priority mapping in `data/priorities.csv`
+
+At this time, the importer assumes you have Pivotal priorities enabled and requires that you map them to Shortcut Priority custom field values. You can straightforwardly comment all mentions of priority from the Python implementation of this importer to have it skip considering Priority mapping.
+
+If your Shortcut workspace has the default Priority custom field enabled, `initialize.py` will identify its Shortcut ID, will populate the `priority_custom_field_id` value in your `config.json` with that ID, and will then populate `data/priorities.csv` with the IDs of the top 4 custom field values (which are "Highest", "High", "Medium", and "Low" by default). If this is satisfactory, no further customization is required on your part.
+
+If you wish to use a different custom field for mapping your Pivotal priority values, you can populate the `priority_custom_field_id` value with that Custom Field ID and then run `make initialize` again to have it populate the default custom field values. If you want further control over how each Pivotal priority is mapped to each custom field value, you can replace the custom field value IDs in the `data/priorities.csv` file to your liking.
+
+Once all Pivotal priorities have a Shortcut priority mapping, initialization can continue successfully.
+
+### Story State mapping in `data/states.csv`
+
+Pivotal has a fixed set of possible story state, but Shortcut supports multiple workflows, each of which has consituent story states.
+
+The `workflow_id` in your `config.json` is the Shortcut ID for the workflow (the container of states).
+
+The `data/states.csv` file maps the individual Pivotal story states to Shortcut story workflow states within the workflow specified by `workflow_id`.
+
+If your Shortcut workspace has the default workflow and its default workflow states, `initialize.py` will identify those and create the `data/states.csv` file with a full mapping from your Pivotal states to Shortcut workflow states.
+
+If your Shortcut workspace does not have the default workflow, or if that workflow has non-standard states (since both of these things are user-editable), then you will need to complete the mapping in `data/states.csv` by reviewing the workflows and workflow states written to `data/shortcut_workflows.csv`, so that every Pivotal story state has a corresponding Shortcut story workflow state.
+
+Once all Pivotal story states have a Shortcut story workflow state mapping, initialization can continue successfully.
+
+### User mapping in `data/users.csv`
+
+Your Pivotal projects contain story requesters, story owners, story reviewers, and commenters, all of which require an identity in Shortcut for a successful import.
+
+The `data/users.csv` file is populated by `initialize.py` with every unique user identified in your Pivotal export. The Pivotal export does not provide email addresses; it provides full names for the users in question.
+
+The `initialize.py` script then checks whether there are users in your Shortcut workspace with full names that match the full names found in the Pivotal export. It automatically maps ones it can find, but leaves blank `shortcut_user_email` entries for any user that doesn't have an exact match.
+
+You must provide an email address for every row in your `data/users.csv` file for initialization to proceed successfully.
+
+If you're still on a Shortcut trial (or if you contact support), you can add users whom you intend to immediately disable, so that you can have a one-to-one mapping from your Pivotal users to your Shortcut users. If you don't care about preserving user history for people who won't be a part of your Shortcut workspace, you can also optionally map all of those users to a single email address for a blanket user that you add to your Shortcut workspace.
+
+Note: The `shortcut_user_mention_name` column is there for your convenience, but is not required for initialization or import. You can leave that column empty for rows that you fill in manually.
+
+## Python: `pivotal_import.py`
+
+Once your `config.json` is in order and all of the rows in `data/priorities.csv`, `data/states.csv`, and `data/users.csv` are filled in, you can proceed with importing your Pivotal export into Shortcut.
+
+The `pivotal_import.py` script defaults to doing a dry run of the import, wherein it: identifies the number of epics, iterations, and stories that would be imported; prints that information to the screen; and populates `data/shortcut_imported_entities.csv` with that mocked data.
+
+Once you have reviewed what the importer has identified, you can run a real import by invoking the `make import-apply` make target. This will print less information to the screen, but it will provide a link to a Shortcut Label page that will automatically update with all of the epics and stories being imported. When complete, the importer will write `data/shortcut_imported_entities.csv` which provides a summary of all the Shortcut epics, iterations, and stories created during the import.
+
+NOTE: Don't delete the `data/shortcut_imported_entities.csv` file; if you need to delete the import and try again, the `make delete` and `make delete-apply` targets depend on it.
+
+## Python: `delete_imported_entities.py`
+
+After performing an import, you may see something that you want to adjust in your configuration, mappings, or in the Python code of this importer itself.
+
+To delete all of the epics, iterations, and stories you just imported, invoke `make delete` to see a dry run of what would be deleted, and then `make delete-apply` to actually delete the Shortcut entities. The underlying `delete_imported_entities.py` script relies on the `data/shortcut_imported_entities.csv` file to determine what to delete, so it shouldn't delete epics, iterations, and stories not found in that CSV file.
+
+When you run `make import-apply` again, a new `data/shortcut_imported_entities.csv` file will be written, so you can cycle through imports and deletions until you're satisfied with the import.
 
 # Contributing
 

--- a/pivotal-import/initialize.py
+++ b/pivotal-import/initialize.py
@@ -124,7 +124,7 @@ def exit_unmapped_pt_priorities(priorities_csv_file, unmapped_pt_priorities):
     )
     printerr(
         f"""To resolve this, please:
-1. Review the Shortcut Custom Fields printed below (also written to {shortcut_custom_fields_csv} for reference)
+1. Review the Shortcut Custom Fields written to {shortcut_custom_fields_csv}
 2. Copy the UUIDs of Custom Field Values (custom_field_value_id column in the CSV) that you want to map to Pivotal priorities where there are blanks in your {priorities_csv_file} file.
 3. Save your {priorities_csv_file} file and rerun initalize.py to validate it.
 """
@@ -236,7 +236,7 @@ def exit_unmapped_pt_states(states_csv_file, unmapped_pt_states):
     )
     printerr(
         f"""To resolve this, please:
-1. Review the Shortcut Workflow States printed below (also written to {shortcut_workflows_csv} for reference)
+1. Review the Shortcut Workflow States written to {shortcut_workflows_csv}
 2. Copy the numeric IDs of Workflow States (workflow_state_id column in the CSV) that you want to map to Pivotal states where there are blanks in your {states_csv_file} file.
 3. Save your {states_csv_file} file and rerun initalize.py to validate it.
 """
@@ -490,7 +490,7 @@ def exit_unmapped_pt_users(users_csv_file, unmapped_pt_users, user_info_list):
     )
     printerr(
         f"""To resolve this, please:
-1. Review the Shortcut users in your workspace, written to {shortcut_users_csv} for your convenience.
+1. Review the Shortcut users in your workspace, written to {shortcut_users_csv}
 2. For users you've already invited to Shortcut, copy their email address from {shortcut_users_csv}
    and fill in the appropriate blank entries in {users_csv_file} for them.
 3. For users you haven't already invited to Shortcut, you can enter their email addresses manually into
@@ -531,7 +531,7 @@ def exit_uninvited_pt_users(uninvited_pt_users):
     printerr(
         f"""To resolve this, invite these people to your Shortcut workspace.
 
-1. Copy the list of emails printed above (also written to {emails_to_invite} for reference).
+1. Copy the list of emails written to {emails_to_invite}
 2. Navigate to https://app.shortcut.com/settings/users/invite
 3. Click "Invite Emails".
 4. Paste the list of emails into the text area.

--- a/pivotal-import/initialize.py
+++ b/pivotal-import/initialize.py
@@ -129,8 +129,6 @@ def exit_unmapped_pt_priorities(priorities_csv_file, unmapped_pt_priorities):
 3. Save your {priorities_csv_file} file and rerun initalize.py to validate it.
 """
     )
-    custom_fields = sc_get("/custom-fields")
-    print_custom_fields_tree(custom_fields)
     sys.exit(1)
 
 
@@ -241,8 +239,6 @@ def exit_unmapped_pt_states(states_csv_file, unmapped_pt_states):
 3. Save your {states_csv_file} file and rerun initalize.py to validate it.
 """
     )
-    workflows = sc_get("/workflows")
-    print_workflows_tree(workflows)
     sys.exit(1)
 
 
@@ -559,7 +555,22 @@ def main(argv):
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
 
+    # Configuration consists of the environment variable SHORTCUT_API_TOKEN and all values
+    # found in the local config.json file (which is written by this script if absent).
     cfg = load_config()
+
+    # Ensure local data/shortcut_*.csv files are populated with user's workspace data,
+    # so they can review what's available for mapping in the steps that follow.
+    custom_fields = sc_get("/custom-fields")
+    print_custom_fields_tree(custom_fields)
+    groups = sc_get("/groups")
+    print_groups_tree(groups)
+    workflows = sc_get("/workflows")
+    print_workflows_tree(workflows)
+
+    # Populate local data/priorities.csv, data/states.csv, and data/users.csv files,
+    # automatically where possible, and print problems to the console where mappings
+    # are not 100% complete.
     populate_priorities_csv(cfg["priorities_csv_file"], cfg["priority_custom_field_id"])
     populate_states_csv(cfg["states_csv_file"], cfg["workflow_id"])
     populate_users_csv(cfg["users_csv_file"], cfg["pt_csv_file"])

--- a/pivotal-import/initialize.py
+++ b/pivotal-import/initialize.py
@@ -562,11 +562,11 @@ def main(argv):
     # Ensure local data/shortcut_*.csv files are populated with user's workspace data,
     # so they can review what's available for mapping in the steps that follow.
     custom_fields = sc_get("/custom-fields")
-    print_custom_fields_tree(custom_fields)
+    write_custom_fields_tree(custom_fields)
     groups = sc_get("/groups")
-    print_groups_tree(groups)
+    write_groups_tree(groups)
     workflows = sc_get("/workflows")
-    print_workflows_tree(workflows)
+    write_workflows_tree(workflows)
 
     # Populate local data/priorities.csv, data/states.csv, and data/users.csv files,
     # automatically where possible, and print problems to the console where mappings

--- a/pivotal-import/lib.py
+++ b/pivotal-import/lib.py
@@ -140,7 +140,7 @@ shortcut_users_csv = "data/shortcut_users.csv"
 shortcut_workflows_csv = "data/shortcut_workflows.csv"
 
 
-def print_custom_fields_tree(custom_fields):
+def write_custom_fields_tree(custom_fields):
     """
     Write to `shortcut_custom_fields_csv` the content of all Custom Fields
     in the user's Shortcut workspace, including all Custom Field Values and their IDs.
@@ -169,7 +169,7 @@ def print_custom_fields_tree(custom_fields):
                     )
 
 
-def print_groups_tree(groups):
+def write_groups_tree(groups):
     """
     Write to `shortcut_groups_csv` the content of all Teams/Groups
     in the user's Shortcut workspace.
@@ -187,7 +187,7 @@ def print_groups_tree(groups):
             writer.writerow({"group_name": group["name"], "group_id": group["id"]})
 
 
-def print_workflows_tree(workflows):
+def write_workflows_tree(workflows):
     """
     Write to `shortcut_workflows_csv` the content of all Workflows
     in the user's Shortcut workspace, including all Workflow States and their IDs.

--- a/pivotal-import/lib.py
+++ b/pivotal-import/lib.py
@@ -142,10 +142,9 @@ shortcut_workflows_csv = "data/shortcut_workflows.csv"
 
 def print_custom_fields_tree(custom_fields):
     """
-    Print and write to `shortcut_custom_fields_csv` the content of all Custom Fields
+    Write to `shortcut_custom_fields_csv` the content of all Custom Fields
     in the user's Shortcut workspace, including all Custom Field Values and their IDs.
     """
-    output_lines = []
     with open(shortcut_custom_fields_csv, "w") as f:
         writer = csv.DictWriter(
             f,
@@ -159,9 +158,6 @@ def print_custom_fields_tree(custom_fields):
         writer.writeheader()
         for custom_field in custom_fields:
             if custom_field["enabled"]:
-                output_lines.append(
-                    'Custom Field {id} : "{name}"'.format_map(custom_field)
-                )
                 for custom_field_value in custom_field["values"]:
                     writer.writerow(
                         {
@@ -171,22 +167,13 @@ def print_custom_fields_tree(custom_fields):
                             "custom_field_value_id": custom_field_value["id"],
                         }
                     )
-                    output_lines.append(
-                        '    Custom Field Value {id} : "{value}"'.format_map(
-                            custom_field_value
-                        )
-                    )
-    printerr("Shortcut Custom Fields")
-    printerr("======================")
-    printerr("\n".join(output_lines))
 
 
 def print_groups_tree(groups):
     """
-    Print and write to `shortcut_groups_csv` the content of all Teams/Groups
+    Write to `shortcut_groups_csv` the content of all Teams/Groups
     in the user's Shortcut workspace.
     """
-    output_lines = []
     with open(shortcut_groups_csv, "w") as f:
         writer = csv.DictWriter(
             f,
@@ -198,18 +185,13 @@ def print_groups_tree(groups):
         writer.writeheader()
         for group in groups:
             writer.writerow({"group_name": group["name"], "group_id": group["id"]})
-            output_lines.append('Team/Group {id} : "{name}"'.format_map(group))
-    printerr("Shortcut Teams/Groups")
-    printerr("=====================")
-    printerr("\n".join(output_lines))
 
 
 def print_workflows_tree(workflows):
     """
-    Print and write to `shortcut_workflows_csv` the content of all Workflows
+    Write to `shortcut_workflows_csv` the content of all Workflows
     in the user's Shortcut workspace, including all Workflow States and their IDs.
     """
-    output_lines = []
     with open(shortcut_workflows_csv, "w") as f:
         writer = csv.DictWriter(
             f,
@@ -222,7 +204,6 @@ def print_workflows_tree(workflows):
         )
         writer.writeheader()
         for workflow in workflows:
-            output_lines.append('Workflow {id} : "{name}"'.format_map(workflow))
             for workflow_state in workflow["states"]:
                 writer.writerow(
                     {
@@ -232,14 +213,6 @@ def print_workflows_tree(workflows):
                         "workflow_state_id": workflow_state["id"],
                     }
                 )
-                output_lines.append(
-                    '    Workflow State {id} : [{type}] "{name}"'.format_map(
-                        workflow_state
-                    )
-                )
-    printerr("Shortcut Workflows")
-    printerr("==================")
-    printerr("\n".join(output_lines))
 
 
 def default_group_id():

--- a/pivotal-import/lib.py
+++ b/pivotal-import/lib.py
@@ -238,8 +238,6 @@ def default_group_id():
   4. Rerun initialize.py.
 """
         )
-        print_groups_tree(groups)
-        printerr("\n")
         return None
     else:
         return group_id
@@ -266,10 +264,9 @@ def default_priority_custom_field_id():
  1. Review the Shortcut Custom Fields printed below (also written to {shortcut_custom_fields_csv} for reference).
  2. Copy the UUID of your desired Custom Field (custom_field_id column in the CSV).
  3. Paste it as the "priority_custom_field_id" value in your config.json file.
- 4. Rerun initialize.py."""
+ 4. Rerun initialize.py.
+"""
         )
-        print_custom_fields_tree(custom_fields)
-        printerr("\n")
         return None
     else:
         return priority_custom_field_id
@@ -297,8 +294,6 @@ def default_workflow_id():
   4. Rerun initialize.py.
 """
         )
-        print_workflows_tree(workflows)
-        printerr("\n")
         return None
     else:
         return workflow_id


### PR DESCRIPTION
In addition to documentation, this has the initialization process always write the `data/shortcut_*.csv` files with data from the user's Shortcut workspace, so that it's more at hand.

It also stops printing that data to the console, relying instead on the more regularly-structured CSVs to better capture and convey the data.

Before this PR, those files were only written when something was wrong with a configuration or mapping.