### PR TITLE
Import file attachments

### DIFF
--- a/pivotal-import/.gitignore
+++ b/pivotal-import/.gitignore
@@ -1,13 +1,4 @@
-data/emails_to_invite.csv
-data/pivotal_export.csv
-data/priorities.csv
-data/shortcut_custom_fields.csv
-data/shortcut_groups.csv
-data/shortcut_imported_entities.csv
-data/shortcut_workflows.csv
-data/shortcut_users.csv
-data/states.csv
-data/users.csv
+data/
 config.json
 
 # Python

--- a/pivotal-import/README.md
+++ b/pivotal-import/README.md
@@ -17,7 +17,10 @@ In order to run this, you will require a Pivotal account and the ability to sign
 1. Sign up for a Shortcut account at [https://www.shortcut.com/signup](https://www.shortcut.com/signup).
    - **NOTE:** Do not run this importer against an existing Shortcut workspace that already has data you wish to keep.
 1. [Create a new Shortcut API token](https://app.shortcut.com/settings/account/api-tokens) and [export it into your environment](../Authentication.md).
-1. Export your Pivotal project to CSV and save the file to `data/pivotal_export.csv`.
+1. Export your Pivotal project to CSV.
+   - Unarchive the ZIP file provided by Pivotal.
+   - Copy the primary CSV file to `data/pivotal_export.csv`
+   - (Optional) To import your Pivotal story file attachments, ensure you included them when requesting your Pivotal export, and then copy the directories in your Pivotal export that are named after your Pivotal story IDs (which contain their file attachments) into the `data/` folder of this project. This will result in a directory structure like `data/10000/*`, `data/10001/*`, etc.
 1. Create/Invite all users you want to reference into your Shortcut workspace.
    - **NOTE:** If you're not on a Shortcut trial, please [reach out to our support team](https://help.shortcut.com/hc/en-us/requests/new) before running this import to make sure you're not billed for users that you want to be disabled after import.
 1. Run `make import` to perform a dry-run of the import.
@@ -44,14 +47,14 @@ You can run `make clean` if you want to start over, but be aware this will delet
 
 The following are known limitations:
 
-- **Limited story reviews:** Shortcut does not have a feature equivalent to Pivotal story reviews, so they are imported as follows:
+- **Story reviews:** Shortcut does not have a feature equivalent to Pivotal story reviews, so they are imported as follows:
   - Pivotal story reviewers are imported as Shortcut story followers on the stories they were assigned for review. Shortcut story followers receive updates in their Shortcut Activity Feed for all story updates.
   - Imported stories that had Pivotal reviews have an additional comment with a table that lists all of the story reviews from Pivotal (reviewer, review type, and review status).
   - Imported stories that had Pivotal reviews have a label in Shortcut of `pivotal-had-review`.
+- **File attachments:** Files included in the Pivotal export (and correctly placed in the `data/` folder prior to import) are uploaded and associated with respective imported Shortcut stories. Other kinds of attachments (e.g., Google Drive) are not supported.
 - **No story blockers:** Pivotal story blockers (the relationships between stories) are not imported.
 - **Epics are imported as unstarted:** Imported epics are set to an unstarted "Todo" state.
 - **No redirects:** The URLs in the descriptions and comments of your Pivotal stories/epics are not rewritten to point to imported Shortcut stories/epics; they remain unchanged.
-- **No attachments:** The attachments (including Google Drive attachments) are not imported into Shortcut.
 - **No history:** Project history is not imported into Shortcut.
 
 Our intention is to attend to items higher on the list sooner than those lower.

--- a/pivotal-import/delete_imported_entities.py
+++ b/pivotal-import/delete_imported_entities.py
@@ -23,6 +23,8 @@ def delete_entity(entity_type, entity_id):
         prefix = "/stories/"
     elif entity_type == "epic":
         prefix = "/epics/"
+    elif entity_type == "file":
+        prefix = "/files/"
     elif entity_type == "iteration":
         prefix = "/iterations/"
 

--- a/pivotal-import/lib.py
+++ b/pivotal-import/lib.py
@@ -112,12 +112,11 @@ def sc_put(path, data={}):
 
 
 @rate_decorator(rate_mapping)
-def sc_upload_files(story_id, files):
+def sc_upload_files(files):
     """Upload and associate `files` with the story with given `story_id`"""
     url = f"{api_url_base}/files"
     logger.debug("POST url=%s files=%s headers=%s" % (url, files, headers))
-    responses = []
-    file_ids = []
+    file_entities = []
     for file in files:
         try:
             with open(file, "rb") as f:
@@ -136,12 +135,10 @@ def sc_upload_files(story_id, files):
                 logger.debug(f"POST response: {resp.status_code} {resp.text}")
                 resp.raise_for_status()
                 resp_json = resp.json()
-                file_ids.append(resp_json[0]["id"])
-                responses.append(resp_json)
+                file_entities.append(resp_json[0])
         except:
             printerr(f"[Warning] Failed to upload file {file}")
-    sc_put(f"/stories/{story_id}", {"file_ids": file_ids})
-    return responses
+    return file_entities
 
 
 @rate_decorator(rate_mapping)
@@ -526,7 +523,12 @@ def identity(x):
 
 
 def print_stats(stats):
-    plurals = {"story": "stories", "epic": "epics", "iteration": "iterations"}
+    plurals = {
+        "story": "stories",
+        "epic": "epics",
+        "file": "files",
+        "iteration": "iterations",
+    }
     for k, v in stats.items():
         plural = plurals.get(k, k + "s")
         print(f"  - {plural.capitalize()} : {v}")

--- a/pivotal-import/lib_test.py
+++ b/pivotal-import/lib_test.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import tempfile
 
 import pytest
@@ -44,13 +43,6 @@ def assoc(dict, key, value):
     """Return a copy of `dict` with `key` assigned to `value`"""
     d = deepcopy(dict)
     d[key] = value
-
-
-def dissoc(dict, key_to_remove):
-    """Return a copy of `dict` with `key_to_remove` absent."""
-    d = deepcopy(dict)
-    del d[key_to_remove]
-    return d
 
 
 def test_validate_config_ok():
@@ -113,3 +105,17 @@ def test_parse_date():
 
 def test_parse_date_time():
     assert parse_date_time("Oct 15, 2014") == "2014-10-15T00:00:00"
+
+
+def test_dissoc():
+    d = {"a": "alpha", "b": "beta", "c": "gamma"}
+    assert {"a": "alpha", "b": "beta"} == dissoc(d, "c")
+    assert d == dissoc(d, "")
+    assert {} == dissoc({}, "a")
+
+
+def test_guess_mime_type():
+    assert "application/json" == guess_mime_type("example.json")
+    assert "image/png" == guess_mime_type("example.png")
+    assert "text/plain" == guess_mime_type("example.txt")
+    assert "application/octet-stream" == guess_mime_type("example.unknown_extension")

--- a/pivotal-import/pivotal_import.py
+++ b/pivotal-import/pivotal_import.py
@@ -522,7 +522,9 @@ class EntityCollector:
         for label in self.labels:
             if PIVOTAL_TO_SHORTCUT_RUN_LABEL == label["entity"]["name"]:
                 label_url = label["imported_entity"]["app_url"]
-                print(f"Import Started\n\nVisit {label_url} to monitor import progress")
+                print(
+                    f"Import Started\n\n==> Click here to monitor import progress: {label_url}"
+                )
 
         # create all the epics and find their associated Shortcut epic ids
         self.epics = self.emitter(self.epics)

--- a/pivotal-import/pivotal_import_test.py
+++ b/pivotal-import/pivotal_import_test.py
@@ -558,7 +558,7 @@ def test_entity_collector():
     entity_collector.collect(
         {
             "type": "story",
-            "entity": {"name": "A Story 1"},
+            "entity": {"name": "A Story 1", "external_id": "1234"},
             "iteration": None,
             "pt_iteration_id": None,
         }
@@ -566,7 +566,7 @@ def test_entity_collector():
     entity_collector.collect(
         {
             "type": "story",
-            "entity": {"name": "A Story 2"},
+            "entity": {"name": "A Story 2", "external_id": "4567"},
             "iteration": None,
             "pt_iteration_id": None,
         }
@@ -574,7 +574,7 @@ def test_entity_collector():
     entity_collector.collect(
         {
             "type": "story",
-            "entity": {"name": "A Story 3"},
+            "entity": {"name": "A Story 3", "external_id": "6789"},
             "iteration": None,
             "pt_iteration_id": None,
         }
@@ -588,18 +588,21 @@ def test_entity_collector():
             "id": 0,
             "app_url": "https://example.com/entity/0",
             "entity_type": "story",
+            "external_id": "1234",
         },
         {
             "name": "A Story 2",
             "id": 1,
             "app_url": "https://example.com/entity/1",
             "entity_type": "story",
+            "external_id": "4567",
         },
         {
             "name": "A Story 3",
             "id": 2,
             "app_url": "https://example.com/entity/2",
             "entity_type": "story",
+            "external_id": "6789",
         },
     ] == created
 
@@ -611,7 +614,7 @@ def test_entity_collector_with_epics():
     entity_collector.collect(
         {
             "type": "story",
-            "entity": {"name": "A Story 1"},
+            "entity": {"name": "A Story 1", "external_id": "1234"},
             "iteration": None,
             "pt_iteration_id": None,
         }
@@ -619,7 +622,11 @@ def test_entity_collector_with_epics():
     entity_collector.collect(
         {
             "type": "story",
-            "entity": {"name": "A Story 2", "labels": [{"name": "my-epic-label-2"}]},
+            "entity": {
+                "name": "A Story 2",
+                "labels": [{"name": "my-epic-label-2"}],
+                "external_id": "2345",
+            },
             "iteration": None,
             "pt_iteration_id": None,
         }
@@ -643,7 +650,7 @@ def test_entity_collector_with_epics():
     entity_collector.collect(
         {
             "type": "story",
-            "entity": {"name": "A Story 3"},
+            "entity": {"name": "A Story 3", "external_id": "3456"},
             "iteration": None,
             "pt_iteration_id": None,
         }
@@ -676,6 +683,7 @@ def test_entity_collector_with_epics():
             "id": 2,
             "app_url": "https://example.com/entity/2",
             "entity_type": "story",
+            "external_id": "1234",
         },
         {
             "name": "A Story 2",
@@ -684,11 +692,13 @@ def test_entity_collector_with_epics():
             "id": 3,
             "app_url": "https://example.com/entity/3",
             "entity_type": "story",
+            "external_id": "2345",
         },
         {
             "name": "A Story 3",
             "id": 4,
             "app_url": "https://example.com/entity/4",
             "entity_type": "story",
+            "external_id": "3456",
         },
     ] == created


### PR DESCRIPTION
The Pivotal CSV export includes folders whose names are Pivotal story
IDs. Each folder contains all of the files uploaded to Pivotal Tracker
that were associated with that Pivotal story.

This importer now detects the presence of those folders inside the
`data/` folder of this project. If present, files inside of it are
uploaded to Shortcut, and then associated with stories as the stories
are imported.

The deletion script included with this importer has been updated to
delete files listed in the shortcut_imported_entities.csv file.

## PR Sundries

- Used `dissoc` in mainline code, so moved it into `lib.py` and added a unit test for it
- Made the URL we print for the user to click stand out more
- Added all of `data/` to the `.gitignore`, since `.gitkeep` is already tracked

## Manual Testing

I've manually tested:

* (A) A `make import-apply` import with file attachments for multiple stories, each story having 1–3 attachments, attachments being of different types (image and text)
* (B) A `make import-apply` import with no file attachments
* A `make delete-apply` deletion for (A) and (B)

All of these are working in my test workspace.