### PR TITLE
Update objective_metrics.py

### DIFF
--- a/kanban-metrics/objective_metrics.py
+++ b/kanban-metrics/objective_metrics.py
@@ -3,7 +3,7 @@ import sys
 import requests
 
 # This gets your token from the local environment variable.
-shortcut_api_token = '?token=' + os.getenv('shortcut_api_token')
+shortcut_api_token = '?token=' + os.getenv('SHORTCUT_API_TOKEN')
 
 api_url_base = 'https://api.app.shortcut.com/api/beta'
 objective_endpoint = '/objectives'


### PR DESCRIPTION
Updated case for retrieving SHORTCUT_API_TOKEN env variable. Instructions set the variable in all caps. When in lower case (at least on MacOS) it will generate an error because the variable is not found.