### PR TITLE
Calvinq/sc 282316/default to token permission for reviewer

### DIFF
--- a/pivotal-import/lib.py
+++ b/pivotal-import/lib.py
@@ -60,7 +60,7 @@ headers = {
     "Shortcut-Token": sc_token,
     "Accept": "application/json; charset=utf-8",
     "Content-Type": "application/json",
-    "User-Agent": "pivotal-to-shortcut/0.0.1-alpha1",
+    "User-Agent": "pivotal-to-shortcut/0.0.1-alpha2",
 }
 
 

--- a/pivotal-import/lib.py
+++ b/pivotal-import/lib.py
@@ -286,7 +286,7 @@ def default_priority_custom_field_id():
     priority_custom_field_id = None
     custom_fields = sc_get("/custom-fields")
     for custom_field in custom_fields:
-        if custom_field["canonical_name"] == "priority" and custom_field["enabled"]:
+        if "canonical_name" in custom_field and custom_field["canonical_name"] == "priority" and custom_field["enabled"]:
             priority_custom_field_id = custom_field["id"]
 
     if priority_custom_field_id is None:

--- a/pivotal-import/lib.py
+++ b/pivotal-import/lib.py
@@ -330,6 +330,13 @@ def default_workflow_id():
     else:
         return workflow_id
 
+def current_member_id():
+    """
+    Returns the member id that this token belongs to.
+    """
+    member = sc_get("/member")
+    return member["id"]
+
 
 def populate_config():
     """

--- a/pivotal-import/pivotal_import.py
+++ b/pivotal-import/pivotal_import.py
@@ -305,7 +305,7 @@ def build_entity(ctx, d):
                 review_status = escape_md_table_syntax(review_status)
                 comment_text += f"\n|{reviewer}|{review_type}|{review_status}|"
             comments.append(
-                {"author_id": d.get("requested_by_id", None), "text": comment_text}
+                {"author_id": d.get("requested_by_id", ctx.get("token_member")), "text": comment_text}
             )
 
         # Custom Fields
@@ -626,7 +626,10 @@ def write_created_entities_csv(created_entities):
 
 
 def build_ctx(cfg):
+    member_id = current_member_id()
+
     ctx = {
+        "token_member": member_id,
         "group_id": cfg["group_id"],
         "priority_config": load_priorities(cfg["priorities_csv_file"]),
         "priority_custom_field_id": cfg["priority_custom_field_id"],


### PR DESCRIPTION
## Commits

### fix: Reviewer comment creation fails when `Requested By` is empty

Default to the token's member id if the entities `Requested By` is empty

### fix: KeyError when checking custom fields

Only Shortcut fields have canonical json key
