### PR TITLE
Recipe: Iteration story rollover

### DIFF
--- a/iteration-rollover/README.md
+++ b/iteration-rollover/README.md
@@ -1,0 +1,116 @@
+# Iteration Rollover Report
+
+This script generates a report showing how many times stories in an iteration have "rolled over" from previous iterations. This is useful for identifying work that has been carried over multiple sprints and may need attention.
+
+## What it does
+
+1. Fetches all stories in an iteration
+2. Analyzes the `previous_iteration_ids` field on each story to determine how many times it has rolled over
+3. Groups the results by team (group_id)
+4. Outputs a summary showing:
+   - Total stories per team
+   - Number of stories that rolled over
+   - Percentage of rollover stories
+   - Average number of previous iterations per story
+
+## Requirements
+
+- Python 3
+- `requests` library
+- `pyrate_limiter` library
+
+The top-level Pipfile can be used to install these dependencies.
+
+## Setup
+
+Set your Shortcut API token as an environment variable:
+
+```bash
+export SHORTCUT_API_TOKEN="your-api-token-here"
+```
+
+## Usage
+
+### Analyze the latest started iteration
+
+```bash
+python iteration_rollover.py
+```
+
+This will find the most recently started iteration in your workspace and generate a rollover report.
+
+### Analyze a specific iteration
+
+```bash
+python iteration_rollover.py --iteration-id 12345
+```
+
+### Output to CSV
+
+```bash
+python iteration_rollover.py --output-file rollover-report.csv
+```
+
+### Enable debug logging
+
+```bash
+python iteration_rollover.py --debug
+```
+
+## Example Output
+
+```
+============================================================
+Iteration Rollover Report
+============================================================
+Iteration: Sprint 42
+ID: 12345
+Start Date: 2024-01-15
+End Date: 2024-01-29
+============================================================
+
+SUMMARY BY TEAM
+------------------------------------------------------------
+Team                           Total    Rolled   % Rolled   Avg Prev
+------------------------------------------------------------
+Backend Team                   15       5        33.3       0.67
+Frontend Team                  12       3        25.0       0.42
+Platform Team                  8        2        25.0       0.38
+(No Team Assigned)             3        1        33.3       0.33
+------------------------------------------------------------
+TOTAL                          38       11       28.9
+
+DETAILED BREAKDOWN BY TEAM
+============================================================
+
+Backend Team
+----------------------------------------
+  [3 prev]   Implement user authentication refactor
+  [2 prev]   Fix database connection pooling
+  [new]      Add API rate limiting
+  [new]      Update logging format
+  ...
+```
+
+## CSV Output Format
+
+When using `--output-file`, the CSV contains the following columns:
+
+| Column                   | Description                                     |
+| ------------------------ | ----------------------------------------------- |
+| iteration_id             | ID of the analyzed iteration                    |
+| iteration_name           | Name of the analyzed iteration                  |
+| group_id                 | Team ID (empty for unassigned stories)          |
+| group_name               | Team name                                       |
+| story_id                 | Story ID                                        |
+| story_name               | Story name                                      |
+| story_type               | Type of story (feature, bug, chore)             |
+| previous_iteration_count | Number of previous iterations this story was in |
+| previous_iteration_ids   | Comma-separated list of previous iteration IDs  |
+| app_url                  | Link to the story in Shortcut                   |
+
+## Notes
+
+- Stories without a team assignment are grouped under "(No Team Assigned)"
+- The script adheres to Shortcut's API rate limiting (200 requests/minute)
+- If an iteration has no stories, the script will indicate this and exit cleanly

--- a/iteration-rollover/iteration_rollover.py
+++ b/iteration-rollover/iteration_rollover.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Generate a report of story rollover from iteration to iteration.
+
+This script analyzes stories in an iteration and reports how many previous
+iterations each story has been in, grouped by team (group_id).
+
+Usage:
+    # Analyze the latest started iteration
+    python iteration_rollover.py
+
+    # Analyze a specific iteration by ID
+    python iteration_rollover.py --iteration-id 12345
+
+    # Output to CSV
+    python iteration_rollover.py --output-file rollover-report.csv
+"""
+
+import argparse
+import csv
+import logging
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+
+from lib import print_rate_limiting_explanation, sc_get, validate_environment
+
+parser = argparse.ArgumentParser(
+    description="Generate a report of story rollover from iteration to iteration",
+)
+parser.add_argument(
+    "--iteration-id",
+    dest="iteration_id",
+    type=int,
+    help="Specific iteration ID to analyze. If not provided, uses the latest started iteration.",
+)
+parser.add_argument(
+    "--output-file",
+    dest="output_file",
+    help="Name of file to write CSV results to. If not provided, outputs to stdout.",
+)
+parser.add_argument("--debug", action="store_true", help="Turns on debugging logs")
+
+
+def parse_date(date_str):
+    """Parse an ISO date string, handling various formats."""
+    # Handle Z suffix
+    date_str = date_str.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(date_str)
+    except ValueError:
+        # Fallback: parse just the date portion
+        dt = datetime.strptime(date_str[:10], "%Y-%m-%d")
+    # Make timezone-aware if naive
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def get_latest_started_iteration():
+    """Find the most recently started iteration that is currently in progress."""
+    logging.info("Fetching all iterations...")
+    iterations = sc_get("/iterations")
+
+    now = datetime.now(timezone.utc)
+
+    # Filter to iterations that have started (start_date <= now)
+    started_iterations = []
+    for it in iterations:
+        start_date = parse_date(it["start_date"])
+        if start_date <= now:
+            started_iterations.append(it)
+
+    if not started_iterations:
+        logging.error("No started iterations found in your workspace.")
+        sys.exit(1)
+
+    # Sort by start_date descending to get the most recently started
+    started_iterations.sort(
+        key=lambda x: parse_date(x["start_date"]),
+        reverse=True,
+    )
+
+    return started_iterations[0]
+
+
+def get_iteration_by_id(iteration_id):
+    """Fetch a specific iteration by ID."""
+    logging.info(f"Fetching iteration {iteration_id}...")
+    return sc_get(f"/iterations/{iteration_id}")
+
+
+def get_iteration_stories(iteration_id):
+    """Fetch all stories in an iteration."""
+    logging.info(f"Fetching stories for iteration {iteration_id}...")
+    return sc_get(f"/iterations/{iteration_id}/stories")
+
+
+def get_groups():
+    """Fetch all groups (teams) in the workspace and return as a dict keyed by ID."""
+    logging.info("Fetching groups (teams)...")
+    groups = sc_get("/groups")
+    return {g["id"]: g for g in groups}
+
+
+def analyze_rollover(stories, groups):
+    """
+    Analyze stories for rollover information.
+
+    Returns a dict keyed by group_id containing:
+    - group_name: Name of the team
+    - stories: List of story info dicts with rollover counts
+    - total_stories: Count of stories in this group
+    - rollover_stories: Count of stories that rolled over from previous iterations
+    - total_previous_iterations: Sum of all previous iterations across stories
+    """
+    results = defaultdict(
+        lambda: {
+            "group_name": None,
+            "stories": [],
+            "total_stories": 0,
+            "rollover_stories": 0,
+            "total_previous_iterations": 0,
+        }
+    )
+
+    for story in stories:
+        group_id = story.get("group_id")
+        previous_iteration_ids = story.get("previous_iteration_ids", [])
+        rollover_count = len(previous_iteration_ids)
+
+        # Handle stories without a team assignment
+        if group_id is None:
+            group_key = "unassigned"
+            group_name = "(No Team Assigned)"
+        else:
+            group_key = group_id
+            group_name = groups.get(group_id, {}).get(
+                "name", f"Unknown Team ({group_id})"
+            )
+
+        results[group_key]["group_name"] = group_name
+        results[group_key]["total_stories"] += 1
+        results[group_key]["total_previous_iterations"] += rollover_count
+
+        if rollover_count > 0:
+            results[group_key]["rollover_stories"] += 1
+
+        results[group_key]["stories"].append(
+            {
+                "story_id": story["id"],
+                "story_name": story["name"],
+                "story_type": story.get("story_type", "unknown"),
+                "previous_iteration_count": rollover_count,
+                "previous_iteration_ids": previous_iteration_ids,
+                "app_url": story.get("app_url", ""),
+            }
+        )
+
+    return dict(results)
+
+
+def print_report(iteration, results):
+    """Print the rollover report to stdout."""
+    print(f"\n{'=' * 60}")
+    print("Iteration Rollover Report")
+    print(f"{'=' * 60}")
+    print(f"Iteration: {iteration['name']}")
+    print(f"ID: {iteration['id']}")
+    print(f"Start Date: {iteration['start_date'][:10]}")
+    print(f"End Date: {iteration['end_date'][:10]}")
+    print(f"{'=' * 60}\n")
+
+    if not results:
+        print("No stories found in this iteration.")
+        return
+
+    # Summary by team
+    print("SUMMARY BY TEAM")
+    print("-" * 60)
+    print(f"{'Team':<30} {'Total':<8} {'Rolled':<8} {'% Rolled':<10} {'Avg Prev':<10}")
+    print("-" * 60)
+
+    total_all = 0
+    rollover_all = 0
+
+    for group_key in sorted(results.keys(), key=lambda k: results[k]["group_name"]):
+        data = results[group_key]
+        total = data["total_stories"]
+        rolled = data["rollover_stories"]
+        pct = (rolled / total * 100) if total > 0 else 0
+        avg_prev = (data["total_previous_iterations"] / total) if total > 0 else 0
+
+        total_all += total
+        rollover_all += rolled
+
+        name = data["group_name"][:28]
+        print(f"{name:<30} {total:<8} {rolled:<8} {pct:<10.1f} {avg_prev:<10.2f}")
+
+    print("-" * 60)
+    pct_all = (rollover_all / total_all * 100) if total_all > 0 else 0
+    print(f"{'TOTAL':<30} {total_all:<8} {rollover_all:<8} {pct_all:<10.1f}")
+    print()
+
+    # Detailed breakdown by team
+    print("\nDETAILED BREAKDOWN BY TEAM")
+    print("=" * 60)
+
+    for group_key in sorted(results.keys(), key=lambda k: results[k]["group_name"]):
+        data = results[group_key]
+        print(f"\n{data['group_name']}")
+        print("-" * 40)
+
+        # Sort stories by rollover count descending
+        sorted_stories = sorted(
+            data["stories"], key=lambda s: s["previous_iteration_count"], reverse=True
+        )
+
+        for story in sorted_stories:
+            prev_count = story["previous_iteration_count"]
+            indicator = f"[{prev_count} prev]" if prev_count > 0 else "[new]"
+            print(f"  {indicator:<10} {story['story_name'][:45]}")
+
+
+def write_csv_report(output_file, iteration, results):
+    """Write the rollover report to a CSV file."""
+    logging.info(f"Writing report to {output_file}...")
+
+    fieldnames = [
+        "iteration_id",
+        "iteration_name",
+        "group_id",
+        "group_name",
+        "story_id",
+        "story_name",
+        "story_type",
+        "previous_iteration_count",
+        "previous_iteration_ids",
+        "app_url",
+    ]
+
+    with open(output_file, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for group_key, data in results.items():
+            for story in data["stories"]:
+                writer.writerow(
+                    {
+                        "iteration_id": iteration["id"],
+                        "iteration_name": iteration["name"],
+                        "group_id": group_key if group_key != "unassigned" else "",
+                        "group_name": data["group_name"],
+                        "story_id": story["story_id"],
+                        "story_name": story["story_name"],
+                        "story_type": story["story_type"],
+                        "previous_iteration_count": story["previous_iteration_count"],
+                        "previous_iteration_ids": ",".join(
+                            str(i) for i in story["previous_iteration_ids"]
+                        ),
+                        "app_url": story["app_url"],
+                    }
+                )
+
+    print(f"Report written to {output_file}")
+
+
+def main(argv):
+    args = parser.parse_args(argv[1:])
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    validate_environment()
+    print_rate_limiting_explanation()
+
+    # Get the iteration to analyze
+    if args.iteration_id:
+        iteration = get_iteration_by_id(args.iteration_id)
+    else:
+        iteration = get_latest_started_iteration()
+        logging.info(
+            f"Using latest started iteration: {iteration['name']} (ID: {iteration['id']})"
+        )
+
+    # Fetch stories and groups
+    stories = get_iteration_stories(iteration["id"])
+    groups = get_groups()
+
+    if not stories:
+        print(f"No stories found in iteration '{iteration['name']}'")
+        return 0
+
+    # Analyze rollover
+    results = analyze_rollover(stories, groups)
+
+    # Output results
+    if args.output_file:
+        write_csv_report(args.output_file, iteration, results)
+    else:
+        print_report(iteration, results)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/iteration-rollover/lib.py
+++ b/iteration-rollover/lib.py
@@ -1,0 +1,91 @@
+"""Helper functions for communicating with the Shortcut API.
+
+Expects the Shortcut token to be set in the SHORTCUT_API_TOKEN
+environment variable.
+
+"""
+
+import sys
+import os
+import logging
+
+from pyrate_limiter import Duration, InMemoryBucket, Limiter, Rate  # type: ignore
+import requests
+
+# Logging
+logger = logging.getLogger(__name__)
+
+# Rate limiting. See https://developer.shortcut.com/api/rest/v3#Rate-Limiting
+# The Shortcut API limit is 200 per minute; the 200th request within 60 seconds
+# will receive an HTTP 429 response.
+#
+# The rate limiting config below sets an in-memory limit that is just below
+# Shortcut's rate limit to reduce the possibility of being throttled, and sets
+# the amount of time it will wait once it reaches that limit to just
+# over a minute to account for possible computer clock differences.
+max_requests_per_minute = 200
+rate = Rate(max_requests_per_minute - 5, Duration.MINUTE)
+bucket = InMemoryBucket([rate])
+max_limiter_delay_seconds = 70
+limiter = Limiter(
+    bucket, raise_when_fail=True, max_delay=Duration.SECOND * max_limiter_delay_seconds
+)
+
+
+def rate_mapping(*args, **kwargs):
+    return "shortcut-api-request", 1
+
+
+rate_decorator = limiter.as_decorator()
+
+
+def print_rate_limiting_explanation():
+    printerr(
+        f"""[Note] This script adheres to the Shortcut API rate limit of {max_requests_per_minute} requests per minute.
+       It may pause for up to {max_limiter_delay_seconds} seconds during processing to avoid request throttling."""
+    )
+
+
+# API Helpers
+sc_token = os.getenv("SHORTCUT_API_TOKEN")
+api_url_base = "https://api.app.shortcut.com/api/v3"
+headers = {
+    "Shortcut-Token": sc_token,
+    "Accept": "application/json; charset=utf-8",
+    "Content-Type": "application/json",
+    "User-Agent": "shortcut-api-cookbook/0.0.1-alpha1",
+}
+
+
+@rate_decorator(rate_mapping)
+def sc_get(path, params={}):
+    """
+    Make a GET api call.
+
+    Serializes params as url query parameters.
+    """
+    url = api_url_base + path
+    logger.debug("GET url=%s params=%s headers=%s" % (url, params, headers))
+    resp = requests.get(url, headers=headers, params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def printerr(s):
+    print(s, file=sys.stderr)
+
+
+def validate_environment():
+    """
+    Validate environment settings that must be in place to populate and load
+    the default configuration for this script.
+    """
+    problems = []
+    if sc_token is None:
+        problems.append(
+            " - You must define a SHORTCUT_API_TOKEN environment variable with your Shortcut API token."
+        )
+    if problems:
+        msg = "\n".join(problems)
+        printerr(f"Problems:\n{msg}")
+        sys.exit(1)


### PR DESCRIPTION
Implemented using OpenCode with Claude Opus 4.5, started off with the following prompt:

> Create a recipe for making a report of roll-over of stories from iteration to iteration. Without arguments, the script should find the latest started iteration in the Shortcut workspace, get a listing of all the stories, then look at the `previous_iteration_ids` of each one to calculate a count of how many previous iterations each story has been in. This data should be grouped by group_id (team) that owns the stories in question.
>
> This script should also support an argument that is an iteration ID, so that a specific iteration's stories can be analyzed and not just the "currently active" iteration.